### PR TITLE
html5: Fix gulp build to create build/ directory

### DIFF
--- a/html5/configure.js
+++ b/html5/configure.js
@@ -55,6 +55,11 @@ exports.local = function configure(env, global, local) {
 exports.build = function(env, global, local, cb) {
   var b = browserify({basedir: __dirname});
   b.add('./' + pkg.main);
+
+  var bundleDir = path.dirname(global.html5Bundle);
+  if (!fs.existsSync(bundleDir))
+    fs.mkdirSync(bundleDir);
+
   var out = fs.createWriteStream(global.html5Bundle);
 
   if(!isDev(env)) {


### PR DESCRIPTION
Fresh checkout does not contain build/ directory, therefore
fs.createWriteStream fails.

This commits adds a synchronous check + mkdir to create the directory
on the first run.

/to @ritch please review & merge at will.
