### PR TITLE
models: add default value for Todo.created

### DIFF
--- a/models.json
+++ b/models.json
@@ -15,8 +15,7 @@
         "default": false
       },
       "created": {
-        "type": "number",
-        "//default": "//TODO: Date.now"
+        "type": "number"
       }
     },
     "dataSource": "db"

--- a/models/todo.js
+++ b/models/todo.js
@@ -4,6 +4,8 @@ var async = require('async');
 module.exports = function(app) {
   var Todo = app.models.Todo;
 
+  Todo.definition.properties.created.default = Date.now;
+
   Todo.beforeSave = function(next, model) {
     if (!model.id) model.id = 't-' + Math.floor(Math.random() * 10000).toString();
     next();


### PR DESCRIPTION
Modify Todo definition and set `properties.created.default` to
`Date.now`.

This commit is a follow-up for #7, which moved Todo definition
to models.json, but did not configured the default value for `created`.

/cc @ritch just FYI, there isn't much to review.
