### PR TITLE
Fix build to create html5/build first

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,9 @@ gulp.task('run', function(cb) {
     })
     .on('change', function() {
       // TODO(ritch) only build the package that changed
-      findAndBuild('*');
+      findAndBuild('*', function(err) {
+        cb(err);
+      });
     })
     .on('restart', function () {
       console.log('restarted!');

--- a/html5/configure.js
+++ b/html5/configure.js
@@ -7,6 +7,8 @@ var browserify = require('browserify');
 var sh = require('shelljs');
 var BootConfigLoader = require('loopback-boot').ConfigLoader;
 
+var buildDir = path.resolve(__dirname, 'build');
+
 exports.global = function(env, global) {
   // routes
   global.routes = {
@@ -44,7 +46,7 @@ exports.global = function(env, global) {
   if(!isDev(env)) global.bundle += '.min';
   global.bundle += '.js';
   global.html5Views = path.join(__dirname, 'views');
-  global.html5Bundle = path.join(__dirname, 'build', global.bundle);
+  global.html5Bundle = path.join(buildDir, global.bundle);
   global.bundleURL = '/' + global.bundle;
 }
 
@@ -64,6 +66,14 @@ exports.local = function configure(env, global, local) {
 
 exports.build = function(env, global, local, cb) {
   async.waterfall([
+    function createBuildDir(next) {
+      fs.exists(buildDir, function(yes) {
+        if (yes)
+          next();
+        else
+          fs.mkdir(buildDir, next);
+      });
+    },
     function(next) {
       async.parallel([
         function(next) {


### PR DESCRIPTION
Add a build step to `html5/configure.js` to create `html5/build`
before writing datasources.js and models.js files to that directory.

Modify the master gulpfile to report build errors on reload.

Close #12 

/to @ritch please review
