### PR TITLE
web/app: configure path to page templates

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -19,6 +19,9 @@ app.locals({
 // view engine
 app.engine('html', require('ejs').renderFile);
 
+// fix the path to page templates - it is $pwd/views by default
+app.set('views', path.join(__dirname, 'views'));
+
 // html5 routes
 var routes = CONFIG.routes;
 Object


### PR DESCRIPTION
Express searches page templates in `$(pwd)/view` by default.
That obviously does not work when the server is started via

```
node web/app
```

In this commit, the express app is configured with a views path
resolved using `__dirname`, which makes it independent on the current
working directory.

/to @ritch please review

This patch resolved the regression introduced by #10 as described in #12.
