### PR TITLE
Use Model.remoteMethod instead of loopback's fn.

### DIFF
--- a/models/todo.js
+++ b/models/todo.js
@@ -39,8 +39,9 @@ module.exports = function(Todo/*, Base*/) {
     }
   };
 
-  loopback.remoteMethod(Todo.stats, {
+  Todo.remoteMethod('stats', {
     accepts: {arg: 'filter', type: 'object'},
-    returns: {arg: 'stats', type: 'object'}
-  });
+    returns: {arg: 'stats', type: 'object'},
+    http: { path: '/stats' }
+  }, Todo.stats);
 };


### PR DESCRIPTION
Rework Todo model to define the remote method `stats` using the new
method `Model.remoteMethod` instead of the deprecated
`loopback.remoteMethod`.

/to @ritch 

This is a follow-up for the discussion in #31.
