### PR TITLE
server: refactor middleware registration

### DIFF
--- a/server/app-server.js
+++ b/server/app-server.js
@@ -5,11 +5,12 @@ var explorer = require('loopback-explorer');
 
 var app = module.exports = loopback();
 
-boot(app, __dirname);
-
 // middleware
 app.use(loopback.compress());
 
+// it's important to register the livereload middleware
+// after any response-processing middleware like compress,
+// but before any middleware serving actual content
 var livereload = app.get('livereload');
 if (livereload) {
   app.use(require('connect-livereload')({
@@ -17,45 +18,13 @@ if (livereload) {
   }));
 }
 
-// mount the REST API and the API explorer
-var restApp = require('../rest');
-var restApiRoot = app.get('restApiRoot');
-app.use(restApiRoot, restApp);
-
-var explorerApp = explorer(restApp, { basePath: restApiRoot });
-app.use('/explorer', explorerApp);
-app.once('started', function(baseUrl) {
-  console.log('Browse your REST API at %s%s', baseUrl, explorerApp.mountpath);
-});
+// boot scripts mount components like REST API
+boot(app, __dirname);
 
 // Mount static files like ngapp
 // All static middleware should be registered at the end, as all requests
 // passing the static middleware are hitting the file system
-var isDevEnv = app.get('env') === 'development';
-var NGAPP_INDEX = require.resolve(isDevEnv ?
-  '../ngapp/index.html' : '../ngapp/dist/index.html');
-
-// html5 routes
-var routes = require('../ngapp/config/routes');
-Object
-  .keys(routes)
-  .forEach(function(route) {
-    app.get(route, function(req, res) {
-      res.sendfile(NGAPP_INDEX);
-    });
-  });
-
-// ngapp files
-app.use(loopback.static(path.dirname(NGAPP_INDEX)));
-
-// assets in the development mode
-if (isDevEnv) {
-  app.use(loopback.static(path.resolve(__dirname, '../.tmp')));
-  app.use('/bower_components',
-    loopback.static(path.resolve(__dirname, '../bower_components')));
-  app.use('/lbclient',
-    loopback.static(path.resolve(__dirname, '../lbclient')));
-}
+app.use(loopback.static(path.dirname(app.get('indexFile'))));
 
 // Requests that get this far won't be handled
 // by any middleware. Convert them into a 404 error

--- a/server/app.local.js
+++ b/server/app.local.js
@@ -1,6 +1,11 @@
 var GLOBAL_CONFIG = require('../global-config');
 
+var isDevEnv = (process.env.NODE_ENV || 'development') === 'development';
+
 module.exports = {
   restApiRoot: GLOBAL_CONFIG.restApiRoot,
   livereload: process.env.LIVE_RELOAD,
+  isDevEnv: isDevEnv,
+  indexFile: require.resolve(isDevEnv ?
+    '../ngapp/index.html' : '../ngapp/dist/index.html'),
 };

--- a/server/boot/angular-routes.js
+++ b/server/boot/angular-routes.js
@@ -1,0 +1,10 @@
+module.exports = function(app) {
+  var routes = require('../../ngapp/config/routes');
+  Object
+    .keys(routes)
+    .forEach(function(route) {
+      app.get(route, function(req, res) {
+        res.sendfile(app.get('indexFile'));
+      });
+    });
+};

--- a/server/boot/dev-assets.js
+++ b/server/boot/dev-assets.js
@@ -1,0 +1,15 @@
+var path = require('path');
+
+module.exports = function(app) {
+  if (!app.get('isDevEnv')) return;
+
+  var serveDir = app.loopback.static;
+
+  app.use(serveDir(projectPath('.tmp')));
+  app.use('/bower_components', serveDir(projectPath('bower_components')));
+  app.use('/lbclient', serveDir(projectPath('lbclient')));
+};
+
+function projectPath(relative) {
+  return path.resolve(__dirname, '../..', relative);
+}

--- a/server/boot/explorer.js
+++ b/server/boot/explorer.js
@@ -1,0 +1,12 @@
+var explorer = require('loopback-explorer');
+
+module.exports = function(app) {
+  var restApp = require('../../rest');
+  var restApiRoot = app.get('restApiRoot');
+
+  var explorerApp = explorer(restApp, { basePath: restApiRoot });
+  app.use('/explorer', explorerApp);
+  app.once('started', function(baseUrl) {
+    console.log('Browse your REST API at %s%s', baseUrl, explorerApp.mountpath);
+  });
+};

--- a/server/boot/rest-api.js
+++ b/server/boot/rest-api.js
@@ -1,0 +1,5 @@
+module.exports = function(app) {
+  var restApp = require('../../rest');
+  var restApiRoot = app.get('restApiRoot');
+  app.use(restApiRoot, restApp);
+};


### PR DESCRIPTION
Move the code from the main server file into multiple smaller scripts
in `server/boot/`.

/to @ritch Please review.

The main server file is not as clean as I would like it to be, but this is the best I can come up with without having to prefix all `server/boot` files with numbers, e.g. `server/boot/01-compress.js`.
