### PR TITLE
common: update models/todo.js signature

### DIFF
--- a/common/models/todo.js
+++ b/common/models/todo.js
@@ -1,7 +1,7 @@
 var loopback = require('loopback');
 var async = require('async');
 
-module.exports = function(Todo/*, Base*/) {
+module.exports = function(Todo) {
 
   Todo.definition.properties.created.default = Date.now;
 


### PR DESCRIPTION
Change the function exported by `models/todo.js` to conform to
the new contract expected by loopback-boot: the function exported
has a single argument only.

This is a follow up for https://github.com/strongloop/loopback-boot/pull/26
/cc @raymondfeng @ritch 
