### PR TITLE
Bugfix/grunt serve failing

### DIFF
--- a/client/lbclient/build.js
+++ b/client/lbclient/build.js
@@ -5,7 +5,7 @@ var browserify = require('browserify');
 var boot = require('loopback-boot');
 
 module.exports = function buildBrowserBundle(env, callback) {
-  var b = browserify({ basedir: __dirname });
+  var b = browserify({ basedir: __dirname, ignoreMissing: true });
   b.require('./' + pkg.main, { expose: 'lbclient' });
 
   try {


### PR DESCRIPTION
`grunt serve` fails due to try/catch block for `bcrypt`. This fixes it by adding the `ignore-missing` flag to browserify's bundling options.
