### PR TITLE
Changes that correct the 0-byte concatenations when building dist

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "bower_components"
+  "directory": "client/ngapp/vendor"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 build
 global.config.js
 bower_components
+client/ngapp/vendor
 client/dist
 ngapp/config/bundle.js
 html5/build

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.out
 *.pid
 *.seed
+.idea/
 .DS_Store
 .tmp
 build

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,24 +22,10 @@ module.exports = function (grunt) {
   // Configurable paths for the application
   var appConfig = {
     app: require('./bower.json').appPath || 'app',
-    dist: 'client/dist'
-  }
-    // Configurable paths for the application
-  var bowerJson = require('./bower.json');
-  var bowerRc;
-  try {
-      bowerRc = JSON.parse(fs.readFileSync('./.bowerrc'), 'utf-8');
-  } catch(err) {
-      // No .bowerrc.  Not a problem--it's optional!
-  }
-  var appConfig = {
-      app: (bowerJson && bowerJson.appPath) ? bowerJson.appPath : 'client/ngapp',
-      // vendor: (bowerRc && bowerRc.directory) ? bowerRc.directory : 'client/ngapp/vendor',
-      vendor: (bowerRc && bowerRc.directory) ? bowerRc.directory : 'bower_components',
-      dist: 'client/dist',
-      stage: '.tmp'
+    dist: 'client/dist',
+    stage: '.tmp',
+    vendor: readJSON('./.bowerrc') || 'bower_components'
   };
-
 
   // Define the configuration for all the tasks
   grunt.initConfig({
@@ -412,12 +398,32 @@ module.exports = function (grunt) {
 
   });
 
+  /**
+   * Utility method that parses a JSON file and returns its content as an object.  Exceptions are
+   * silently caught and yield a return value of empty object.
+   *
+   * @param filePath {String} Absolute file path or path relative to current directory.  This is
+   *                          the file whose contents readJSON() attempts to return.
+   * @param charSet {String} Character encoding the file is to be read with.  Defaults to 'utf-8'
+   *                         if omitted.  Optional.
+   */
+  function readJSON(filePath, charSet) {
+    var retVal;
+    try {
+      retVal = JSON.parse(fs.readFileSync(filePath), charSet||'utf-8');
+    } catch(e) {
+      // For this routine's sake, failure is an option, and it shall be a silent one.
+      retVal = {};
+    }
+
+    return retVal;
+  }
   grunt.registerTask('build-lbclient', 'Build lbclient browser bundle', function() {
     var done = this.async();
     buildClientBundle(process.env.NODE_ENV || 'development', done);
   });
 
-  grunt.registerTask('build-config', 'Build confg.js from JSON files', function() {
+  grunt.registerTask('build-config', 'Build config.js from JSON files', function() {
     var ngapp = path.resolve(__dirname, appConfig.app);
     var configDir = path.join(ngapp, 'config');
     var config = {};

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -209,7 +209,7 @@ module.exports = function (grunt) {
           html: {
             steps: {
               js: ['concat', 'uglifyjs'],
-              css: ['concat', 'cssmin']
+              css: ['cssmin']
             },
             post: {}
           }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -201,10 +201,11 @@ module.exports = function (grunt) {
     filerev: {
       dist: {
         src: [
-          // '<%= yeoman.dist %>/scripts/{,*/}*.js',
-          // '<%= yeoman.dist %>/styles/{,*/}*.css',
+          '<%= yeoman.dist %>/scripts/{,*/}*.js',
+          '<%= yeoman.dist %>/styles/{,*/}*.css',
           '<%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}',
-          '<%= yeoman.dist %>/styles/fonts/*'
+          '<%= yeoman.dist %>/styles/fonts/*',
+          '<%= yeoman.dist %>/fonts/*'
         ]
       }
     },
@@ -215,7 +216,7 @@ module.exports = function (grunt) {
     useminPrepare: {
       html: '<%= yeoman.app %>/index.html',
       options: {
-        root: '<%= yeoman.app %>/',
+        root: '<%= yeoman.dist %>/',
         staging: '<%= yeoman.stage %>/',
         dest: '<%= yeoman.dist %>',
         flow: {
@@ -236,9 +237,13 @@ module.exports = function (grunt) {
       css: ['<%= yeoman.dist %>/styles/{,*/}*.css'],
       options: {
         assetsDirs: [
-	  '<%= yeoman.dist %>/images',
-	  '<%= yeoman.dist %>/fonts',
-	  '<%= yeoman.dist %>/styles/fonts'
+          '<%= yeoman.dist %>',
+          '<%= yeoman.dist %>/views',
+          '<%= yeoman.dist %>/fonts',
+          '<%= yeoman.dist %>/images',
+          '<%= yeoman.dist %>/scripts',
+          '<%= yeoman.dist %>/styles',
+          '<%= yeoman.dist %>/styles/fonts'
         ]
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,7 +23,23 @@ module.exports = function (grunt) {
   var appConfig = {
     app: require('./bower.json').appPath || 'app',
     dist: 'client/dist'
+  }
+    // Configurable paths for the application
+  var bowerJson = require('./bower.json');
+  var bowerRc;
+  try {
+      bowerRc = JSON.parse(fs.readFileSync('./.bowerrc'), 'utf-8');
+  } catch(err) {
+      // No .bowerrc.  Not a problem--it's optional!
+  }
+  var appConfig = {
+      app: (bowerJson && bowerJson.appPath) ? bowerJson.appPath : 'client/ngapp',
+      // vendor: (bowerRc && bowerRc.directory) ? bowerRc.directory : 'client/ngapp/vendor',
+      vendor: (bowerRc && bowerRc.directory) ? bowerRc.directory : 'bower_components',
+      dist: 'client/dist',
+      stage: '.tmp'
   };
+
 
   // Define the configuration for all the tasks
   grunt.initConfig({
@@ -61,7 +77,7 @@ module.exports = function (grunt) {
         },
         files: [
           '<%= yeoman.app %>/{,*/}*.html',
-          '.tmp/styles/{,*/}*.css',
+          '<%= yeoman.stage %>/styles/{,*/}*.css',
           '<%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
         ]
       },
@@ -100,17 +116,17 @@ module.exports = function (grunt) {
           port: 9001,
           middleware: function (connect) {
             return [
-              connect.static('.tmp'),
+              connect.static('<%= yeoman.stage %>/'),
               connect.static('test'),
               connect().use(
-                '/bower_components',
-                connect.static('./bower_components')
+                '/vendor',
+                connect.static('<%= yeoman.vendor %>/')
               ),
               connect().use(
                 '/lbclient',
-                connect.static('./lbclient')
+                connect.static('client/lbclient/')
               ),
-              connect.static(appConfig.app)
+              connect.static('<%= yeoman.app %>/')
             ];
           }
         }
@@ -143,13 +159,13 @@ module.exports = function (grunt) {
         files: [{
           dot: true,
           src: [
-            '.tmp',
+            '<%= yeoman.stage %>',
             '<%= yeoman.dist %>/{,*/}*',
             '!<%= yeoman.dist %>/.git*'
           ]
         }]
       },
-      server: '.tmp',
+      server: '<%= yeoman.stage %>',
       lbclient: 'lbclient/browser.bundle.js',
       config: '<%= yeoman.app %>/config/bundle.js'
     },
@@ -162,9 +178,9 @@ module.exports = function (grunt) {
       dist: {
         files: [{
           expand: true,
-          cwd: '.tmp/styles/',
+          cwd: '<%= yeoman.stage %>/styles/',
           src: '{,*/}*.css',
-          dest: '.tmp/styles/'
+          dest: '<%= yeoman.stage %>/styles/'
         }]
       }
     },
@@ -174,11 +190,10 @@ module.exports = function (grunt) {
       options: {
         cwd: '<%= yeoman.app %>',
         bowerJson: require('./bower.json'),
-        directory: './bower_components' //require('./.bowerrc').directory
+        directory: '<%= yeoman.vendor %>' //require('./.bowerrc').directory
       },
       app: {
-        src: ['<%= yeoman.app %>/index.html'],
-        ignorePath:  /..\//
+        src: ['<%= yeoman.app %>/index.html']
       }
     },
 
@@ -186,8 +201,8 @@ module.exports = function (grunt) {
     filerev: {
       dist: {
         src: [
-          '<%= yeoman.dist %>/scripts/{,*/}*.js',
-          '<%= yeoman.dist %>/styles/{,*/}*.css',
+          // '<%= yeoman.dist %>/scripts/{,*/}*.js',
+          // '<%= yeoman.dist %>/styles/{,*/}*.css',
           '<%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}',
           '<%= yeoman.dist %>/styles/fonts/*'
         ]
@@ -200,12 +215,14 @@ module.exports = function (grunt) {
     useminPrepare: {
       html: '<%= yeoman.app %>/index.html',
       options: {
+        root: '<%= yeoman.app %>/',
+        staging: '<%= yeoman.stage %>/',
         dest: '<%= yeoman.dist %>',
         flow: {
           html: {
             steps: {
               js: ['concat', 'uglifyjs'],
-              css: ['cssmin']
+              css: ['concat', 'cssmin']
             },
             post: {}
           }
@@ -218,7 +235,11 @@ module.exports = function (grunt) {
       html: ['<%= yeoman.dist %>/{,*/}*.html'],
       css: ['<%= yeoman.dist %>/styles/{,*/}*.css'],
       options: {
-        assetsDirs: ['<%= yeoman.dist %>','<%= yeoman.dist %>/images']
+        assetsDirs: [
+	  '<%= yeoman.dist %>/images',
+	  '<%= yeoman.dist %>/fonts',
+	  '<%= yeoman.dist %>/styles/fonts'
+        ]
       }
     },
 
@@ -230,7 +251,7 @@ module.exports = function (grunt) {
     //   dist: {
     //     files: {
     //       '<%= yeoman.dist %>/styles/main.css': [
-    //         '.tmp/styles/{,*/}*.css'
+    //         '<%= yeoman.stage %>/styles/{,*/}*.css'
     //       ]
     //     }
     //   }
@@ -295,9 +316,9 @@ module.exports = function (grunt) {
       dist: {
         files: [{
           expand: true,
-          cwd: '.tmp/concat/scripts',
+          cwd: '<%= yeoman.stage %>/concat/scripts',
           src: '*.js',
-          dest: '.tmp/concat/scripts'
+          dest: '<%= yeoman.stage %>/concat/scripts'
         }]
       }
     },
@@ -327,7 +348,7 @@ module.exports = function (grunt) {
           ]
         }, {
           expand: true,
-          cwd: '.tmp/images',
+          cwd: '<%= yeoman.stage %>/images',
           dest: '<%= yeoman.dist %>/images',
           src: ['generated/*']
         }]
@@ -335,7 +356,7 @@ module.exports = function (grunt) {
       styles: {
         expand: true,
         cwd: '<%= yeoman.app %>/styles',
-        dest: '.tmp/styles/',
+        dest: '<%= yeoman.stage %>/styles/',
         src: '{,*/}*.css'
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -202,14 +202,14 @@ module.exports = function (grunt) {
     useminPrepare: {
       html: '<%= yeoman.app %>/index.html',
       options: {
-        root: '<%= yeoman.dist %>/',
+        root: '<%= yeoman.app %>/',
         staging: '<%= yeoman.stage %>/',
         dest: '<%= yeoman.dist %>',
         flow: {
           html: {
             steps: {
               js: ['concat', 'uglifyjs'],
-              css: ['cssmin']
+              css: ['concat', 'cssmin']
             },
             post: {}
           }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,7 +52,7 @@ module.exports = function (grunt) {
       },
       styles: {
         files: ['<%= yeoman.app %>/styles/{,*/}*.css'],
-        tasks: ['newer:copy:styles', 'autoprefixer']
+        tasks: ['autoprefixer']
       },
       gruntfile: {
         files: ['Gruntfile.js']
@@ -164,7 +164,7 @@ module.exports = function (grunt) {
       dist: {
         files: [{
           expand: true,
-          cwd: '<%= yeoman.stage %>/styles/',
+          cwd: '<%= yeoman.app %>/styles/',
           src: '{,*/}*.css',
           dest: '<%= yeoman.stage %>/styles/'
         }]
@@ -185,6 +185,11 @@ module.exports = function (grunt) {
 
     // Renames files for browser caching purposes
     filerev: {
+      options: {
+        encoding: 'utf8',
+        algorithm: 'md5',
+        length: 20
+      },
       dist: {
         src: [
           '<%= yeoman.dist %>/scripts/{,*/}*.js',
@@ -202,8 +207,8 @@ module.exports = function (grunt) {
     useminPrepare: {
       html: '<%= yeoman.app %>/index.html',
       options: {
-        root: '<%= yeoman.app %>/',
-        staging: '<%= yeoman.stage %>/',
+        root: '<%= yeoman.app %>',
+        staging: '<%= yeoman.stage %>',
         dest: '<%= yeoman.dist %>',
         flow: {
           html: {
@@ -242,7 +247,10 @@ module.exports = function (grunt) {
     //   dist: {
     //     files: {
     //       '<%= yeoman.dist %>/styles/main.css': [
-    //         '<%= yeoman.stage %>/styles/{,*/}*.css'
+    //         '<%= yeoman.dist %>/styles/main.css'
+    //       ],
+    //       '<%= yeoman.dist %>/styles/vendor.css': [
+    //         '<%= yeoman.dist %>/styles/vendor.css'
     //       ]
     //     }
     //   }
@@ -252,12 +260,28 @@ module.exports = function (grunt) {
     //     files: {
     //       '<%= yeoman.dist %>/scripts/scripts.js': [
     //         '<%= yeoman.dist %>/scripts/scripts.js'
+    //       ],
+    //       '<%= yeoman.dist %>/scripts/vendor.js': [
+    //         '<%= yeoman.dist %>/scripts/vendor.js'
     //       ]
     //     }
     //   }
     // },
     // concat: {
-    //   dist: {}
+    //   dist: {
+    //     files: {
+    //       '<%= yeoman.dist %>/styles/main.css': [
+    //         '<%= yeoman.stage %>/styles/{,*/}*.css'
+    //       ],
+    //       '<%= yeoman.dist %>/scripts/scripts.js': [
+    //         '<%= yeoman.app %>/scripts/{,*/}*.js'
+    //       ]
+    //       NOTE: No manual way to account for inferred vendor concatenation!!
+    //             There is no simple glob that yields the equivalent of what
+    //             wiredep places in index.html where useminPrepare finds it
+    //             to extract a file list from js and css vendor concat blocks...
+    //     }
+    //   }
     // },
 
     imagemin: {
@@ -266,6 +290,11 @@ module.exports = function (grunt) {
           expand: true,
           cwd: '<%= yeoman.app %>/images',
           src: '{,*/}*.{png,jpg,jpeg,gif}',
+          dest: '<%= yeoman.dist %>/images'
+        }, {
+          expand: true,
+          cwd: '<%= yeoman.stage %>/images',
+          src: 'generated/*.{png,jpg,jpeg,gif}',
           dest: '<%= yeoman.dist %>/images'
         }]
       }
@@ -277,6 +306,11 @@ module.exports = function (grunt) {
           expand: true,
           cwd: '<%= yeoman.app %>/images',
           src: '{,*/}*.svg',
+          dest: '<%= yeoman.dist %>/images'
+        }, {
+          expand: true,
+          cwd: '<%= yeoman.stage %>/images',
+          src: 'generated/*.svg',
           dest: '<%= yeoman.dist %>/images'
         }]
       }
@@ -335,33 +369,22 @@ module.exports = function (grunt) {
             '*.html',
             'views/{,*/}*.html',
             'images/{,*/}*.{webp}',
+            'styles/fonts/*',
             'fonts/*'
           ]
         }, {
           expand: true,
           cwd: '<%= yeoman.stage %>/images',
           dest: '<%= yeoman.dist %>/images',
-          src: ['generated/*']
+          src: 'generated/*.{webp}'
         }]
-      },
-      styles: {
-        expand: true,
-        cwd: '<%= yeoman.app %>/styles',
-        dest: '<%= yeoman.stage %>/styles/',
-        src: '{,*/}*.css'
       }
     },
 
     // Run some tasks in parallel to speed up the build process
     concurrent: {
-      server: [
-        'copy:styles'
-      ],
-      test: [
-        'copy:styles'
-      ],
       dist: [
-        'copy:styles',
+        'copy:dist',
         'imagemin',
         'svgmin'
       ]
@@ -487,7 +510,6 @@ module.exports = function (grunt) {
       'build-lbclient',
       'build-config',
       'wiredep',
-      'concurrent:server',
       'autoprefixer',
       'run:development',
       'watch'
@@ -503,7 +525,6 @@ module.exports = function (grunt) {
     'clean:server',
     'build-lbclient',
     'build-config',
-    'concurrent:test',
     'autoprefixer',
     'connect:test',
     'karma'
@@ -528,15 +549,14 @@ module.exports = function (grunt) {
     'build-lbclient',
     'build-config',
     'wiredep',
-    'useminPrepare',
-    'concurrent:dist',
     'autoprefixer',
-    'concat',
+    'useminPrepare',
+    'concat:generated',
     'ngAnnotate',
-    'copy:dist',
-    'cdnify',
-    'cssmin',
-    'uglify',
+    'concurrent:dist',
+    'cssmin:generated',
+    'uglify:generated',
+    // 'cdnify',
     'filerev',
     'usemin',
     'htmlmin'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
     app: require('./bower.json').appPath || 'app',
     dist: 'client/dist',
     stage: '.tmp',
-    vendor: readJSON('./.bowerrc') || 'bower_components'
+    vendor: readJSON('./.bowerrc').directory || 'bower_components'
   };
 
   // Define the configuration for all the tasks

--- a/client/lbclient/build.js
+++ b/client/lbclient/build.js
@@ -5,7 +5,19 @@ var browserify = require('browserify');
 var boot = require('loopback-boot');
 
 module.exports = function buildBrowserBundle(env, callback) {
-  var b = browserify({ basedir: __dirname });
+  var isDevEnv = ~['debug', 'development', 'test'].indexOf(env);
+  var b = browserify(
+    { basedir: __dirname },
+    { // TODO(bajtos) debug should be always true, the sourcemaps should be
+      // saved to a standalone file when !isDev(env)
+      // TODO(jch) Assess https://github.com/thlorenz/exorcist#usage as an
+      // non-dev build extra step for extracting source maps from the bundle
+      // after generating it.  Browserify does not seem to have an option for
+      // generating them outside the bundle, but this tool is capable of
+      // extracting them after-the-fact.
+      debug: isDevEnv
+    }
+  );
   b.require('./' + pkg.main, { expose: 'lbclient' });
 
   try {
@@ -19,13 +31,8 @@ module.exports = function buildBrowserBundle(env, callback) {
 
   var bundlePath = path.resolve(__dirname, 'browser.bundle.js');
   var out = fs.createWriteStream(bundlePath);
-  var isDevEnv = ~['debug', 'development', 'test'].indexOf(env);
 
-  b.bundle({
-    // TODO(bajtos) debug should be always true, the sourcemaps should be
-    // saved to a standalone file when !isDev(env)
-    debug: isDevEnv
-  })
+  b.bundle()
     .on('error', callback)
     .pipe(out);
 

--- a/client/ngapp/index.html
+++ b/client/ngapp/index.html
@@ -13,11 +13,11 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
-    <!-- build:css(.) styles/vendor.css -->
+    <!-- build:css(client/ngapp) styles/vendor.css -->
     <!-- bower:css -->
     <!-- endbower -->
     <!-- endbuild -->
-    <!-- build:css(.tmp) styles/main.css -->
+    <!-- build:css(client/ngapp) styles/main.css -->
     <link rel="stylesheet" href="styles/main.css">
     <!-- endbuild -->
   </head>
@@ -45,16 +45,16 @@
     <script src="bower_components/json3/lib/json3.min.js"></script>
     <![endif]-->
 
-    <!-- build:js(.) scripts/vendor.js -->
+    <!-- build:js(client/ng-app) scripts/vendor.js -->
     <!-- bower:js -->
-    <script src="../bower_components/es5-shim/es5-shim.js"></script>
-    <script src="../bower_components/angular/angular.js"></script>
-    <script src="../bower_components/json3/lib/json3.js"></script>
-    <script src="../bower_components/angular-route/angular-route.js"></script>
+    <script src="../../bower_components/es5-shim/es5-shim.js"></script>
+    <script src="../../bower_components/angular/angular.js"></script>
+    <script src="../../bower_components/json3/lib/json3.js"></script>
+    <script src="../../bower_components/angular-route/angular-route.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 
-        <!-- build:js({.tmp,ngapp,.}) scripts/scripts.js -->
+    <!-- build:js({client,client/ngapp}) scripts/scripts.js -->
         <script src="lbclient/browser.bundle.js"></script>
         <script src="config/bundle.js"></script>
         <script src="scripts/app.js"></script>

--- a/client/ngapp/index.html
+++ b/client/ngapp/index.html
@@ -6,17 +6,22 @@
 
     <!--
     The base allows us to use relative links to resources even when
-    this page was served from non-root URL, e.g. '/my/todos'
+    this page was served from non-root URL, e.g. '/my/todos'.  Angular
+    HTML5 routing mode also requires this element base to recognize
+    the point from which it should interpret routes as being a reference
+    within the application.
     -->
     <base href="/">
 
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+
     <!-- build:css(client/ngapp) styles/vendor.css -->
     <!-- bower:css -->
     <!-- endbower -->
     <!-- endbuild -->
+
     <!-- build:css(client/ngapp) styles/main.css -->
     <link rel="stylesheet" href="styles/main.css">
     <!-- endbuild -->
@@ -41,8 +46,8 @@
     <div ng-view></div>
 
     <!--[if lt IE 9]>
-    <script src="bower_components/es5-shim/es5-shim.js"></script>
-    <script src="bower_components/json3/lib/json3.min.js"></script>
+    <script src="vendor/es5-shim/es5-shim.js"></script>
+    <script src="vendor/json3/lib/json3.min.js"></script>
     <![endif]-->
 
     <!-- build:js(client/ng-app) scripts/vendor.js -->
@@ -55,16 +60,16 @@
     <!-- endbuild -->
 
     <!-- build:js({client,client/ngapp}) scripts/scripts.js -->
-        <script src="lbclient/browser.bundle.js"></script>
-        <script src="config/bundle.js"></script>
-        <script src="scripts/app.js"></script>
-        <script src="scripts/services/lbclient.js"></script>
-        <script src="scripts/controllers/home.js"></script>
-        <script src="scripts/controllers/user.js"></script>
-        <script src="scripts/controllers/todo.js"></script>
-        <script src="scripts/controllers/login.js"></script>
-        <script src="scripts/controllers/register.js"></script>
-        <script src="scripts/controllers/change.js"></script>
-        <!-- endbuild -->
+    <script src="lbclient/browser.bundle.js"></script>
+    <script src="config/bundle.js"></script>
+    <script src="scripts/app.js"></script>
+    <script src="scripts/services/lbclient.js"></script>
+    <script src="scripts/controllers/home.js"></script>
+    <script src="scripts/controllers/user.js"></script>
+    <script src="scripts/controllers/todo.js"></script>
+    <script src="scripts/controllers/login.js"></script>
+    <script src="scripts/controllers/register.js"></script>
+    <script src="scripts/controllers/change.js"></script>
+    <!-- endbuild -->
 </body>
 </html>

--- a/client/ngapp/index.html
+++ b/client/ngapp/index.html
@@ -17,12 +17,12 @@
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
-    <!-- build:css(client/ngapp) styles/vendor.css -->
+    <!-- build:css styles/vendor.css -->
     <!-- bower:css -->
     <!-- endbower -->
     <!-- endbuild -->
 
-    <!-- build:css(client/ngapp) styles/main.css -->
+    <!-- build:css(.tmp) styles/main.css -->
     <link rel="stylesheet" href="styles/main.css">
     <!-- endbuild -->
   </head>
@@ -50,12 +50,11 @@
     <script src="vendor/json3/lib/json3.min.js"></script>
     <![endif]-->
 
-    <!-- build:js(client/ng-app) scripts/vendor.js -->
+    <!-- build:js scripts/vendor.js -->
     <!-- bower:js -->
-    <script src="../../bower_components/es5-shim/es5-shim.js"></script>
-    <script src="../../bower_components/angular/angular.js"></script>
-    <script src="../../bower_components/json3/lib/json3.js"></script>
-    <script src="../../bower_components/angular-route/angular-route.js"></script>
+    <script src="vendor/angular/angular.js"></script>
+    <script src="vendor/json3/lib/json3.js"></script>
+    <script src="vendor/angular-route/angular-route.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/client/ngapp/test/mock/placeholder.js
+++ b/client/ngapp/test/mock/placeholder.js
@@ -1,0 +1,3 @@
+(function() {
+  console.log('This file is a placeholder.  Please delete it once there are any test mocks in use.');
+}).call(window);

--- a/server/boot/angular-routes.js
+++ b/server/boot/angular-routes.js
@@ -4,7 +4,7 @@ module.exports = function(app) {
     .keys(routes)
     .forEach(function(route) {
       app.get(route, function(req, res) {
-        res.sendfile(app.get('indexFile'));
+        res.sendFile(app.get('indexFile'));
       });
     });
 };

--- a/server/datasources.staging.js
+++ b/server/datasources.staging.js
@@ -5,6 +5,6 @@ module.exports = {
     port: process.env.DB_PORT || 27017,
     user: process.env.DB_USER,
     password: process.env.DB_PASSWORD,
-    database: 'todo-example',
+    database: 'todo-example'
   }
 };


### PR DESCRIPTION
The root problem appears to be that the usemin support tags in HTML are not pointing at directories to which the `<script>` and `<link>` tags.  There's also an issue a little while later that looks like a holdover from when 'lbclient' existed at the root rather than under client.  Since the match yields an empty set, the files that are generated are empty.

I modified the HTML file to begin the path defintion from project root, which meant the comment tags for usemin become (client/ngapp) for all files except lbclient, which is relative to client and not client/ngapp.

In order to make things smoother for the simultaenous dev use case, I relocated bower_components to build under client/ngapp, allowing it to imported from the same relative path in both the dev and dist builds.  The '..' that was getting pruned off by wiredep was a dangerous thing since the periods were not escaped and its used as a regular expression.  The first time I tried this, with minification and concatenation disabled, I found myself staring at failed imports for "vendangular" and "vendunderscore".

I did have to take the CSS and JS concenations out of filerev--for some reason its not accounting for the suffix modification it makes, but perhaps someone can resolve that issue and put them back in?

Anyhow, hope this helps.  I'm eager to see this feature work so it was worth some time to pick apart the build process.  Might as well share the end result.

Connect to #58