### PR TITLE
Render easy-to-read GUIDs for conflicts

### DIFF
--- a/client/lbclient/lbclient.js
+++ b/client/lbclient/lbclient.js
@@ -3,3 +3,6 @@ var boot = require('loopback-boot');
 
 var client = module.exports = loopback();
 boot(client);
+
+module.exports.proquint = require('proquint');
+module.exports.Buffer = Buffer;

--- a/client/ngapp/scripts/controllers/todo.js
+++ b/client/ngapp/scripts/controllers/todo.js
@@ -9,7 +9,8 @@
  */
 angular.module('loopbackExampleFullStackApp')
   .controller('TodoCtrl', function TodoCtrl($scope, $routeParams, $filter, Todo,
-                                            $location, sync, network) {
+                                            $location, sync, network, proquint,
+                                            Buffer) {
   $scope.todos = [];
 
   $scope.newTodo = '';
@@ -126,6 +127,11 @@ angular.module('loopbackExampleFullStackApp')
 
   Todo.on('conflicts', function(conflicts) {
     $scope.localConflicts = conflicts;
+
+    function getSimpleModelId(modelId) {
+      return proquint.encode(new Buffer(modelId.substring(0, 8), 'binary'));
+    }
+
     conflicts.forEach(function(conflict) {
       conflict.type(function(err, type) {
         conflict.type = type;
@@ -136,7 +142,9 @@ angular.module('loopbackExampleFullStackApp')
           $scope.$apply();
         });
         conflict.changes(function(err, source, target) {
+          source.modelId = getSimpleModelId(source.modelId);
           conflict.sourceChange = source;
+          target.modelId = getSimpleModelId(target.modelId);
           conflict.targetChange = target;
           $scope.$apply();
         });

--- a/client/ngapp/scripts/services/lbclient.js
+++ b/client/ngapp/scripts/services/lbclient.js
@@ -17,4 +17,6 @@ angular.module('loopbackExampleFullStackApp')
   .value('Todo', client.models.LocalTodo)
   .value('RemoteTodo', client.models.RemoteTodo)
   .value('sync', client.sync)
-  .value('network', client.network);
+  .value('network', client.network)
+  .value('proquint', client.proquint)
+  .value('Buffer', client.Buffer);

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "loopback-boot": "^2.0.0",
     "loopback-connector-mongodb": "^1.4.1",
     "loopback-datasource-juggler": "^2.0.0",
-    "loopback-explorer": "^1.2.4"
+    "loopback-explorer": "^1.2.4",
+    "proquint": "0.0.1"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
- Use proquint to render easy to read GUIDs
- New IDs are based on the first 8 chars of the original guid

Connect #62 