### PR TITLE
Export getSimpleModelId instead

### DIFF
--- a/client/lbclient/boot/replication.js
+++ b/client/lbclient/boot/replication.js
@@ -7,6 +7,8 @@
 //      target: 'Todo',
 //      mode: 'push' | 'pull' | 'bidi'
 //    }}}
+var proquint = require('proquint');
+
 module.exports = function(client) {
   var LocalTodo = client.models.LocalTodo;
   var RemoteTodo = client.models.RemoteTodo;
@@ -51,4 +53,8 @@ module.exports = function(client) {
   });
 
   client.sync = sync;
+
+  client.getReadableModelId = function(modelId) {
+    return proquint.encode(new Buffer(modelId.substring(0, 8), 'binary'));
+  };
 };

--- a/client/lbclient/lbclient.js
+++ b/client/lbclient/lbclient.js
@@ -3,6 +3,3 @@ var boot = require('loopback-boot');
 
 var client = module.exports = loopback();
 boot(client);
-
-module.exports.proquint = require('proquint');
-module.exports.Buffer = Buffer;

--- a/client/ngapp/scripts/controllers/todo.js
+++ b/client/ngapp/scripts/controllers/todo.js
@@ -9,8 +9,8 @@
  */
 angular.module('loopbackExampleFullStackApp')
   .controller('TodoCtrl', function TodoCtrl($scope, $routeParams, $filter, Todo,
-                                            $location, sync, network, proquint,
-                                            Buffer) {
+                                            $location, sync, network,
+                                            getReadableModelId) {
   $scope.todos = [];
 
   $scope.newTodo = '';
@@ -128,10 +128,6 @@ angular.module('loopbackExampleFullStackApp')
   Todo.on('conflicts', function(conflicts) {
     $scope.localConflicts = conflicts;
 
-    function getSimpleModelId(modelId) {
-      return proquint.encode(new Buffer(modelId.substring(0, 8), 'binary'));
-    }
-
     conflicts.forEach(function(conflict) {
       conflict.type(function(err, type) {
         conflict.type = type;
@@ -142,9 +138,9 @@ angular.module('loopbackExampleFullStackApp')
           $scope.$apply();
         });
         conflict.changes(function(err, source, target) {
-          source.modelId = getSimpleModelId(source.modelId);
+          source.modelId = getReadableModelId(source.modelId);
           conflict.sourceChange = source;
-          target.modelId = getSimpleModelId(target.modelId);
+          target.modelId = getReadableModelId(target.modelId);
           conflict.targetChange = target;
           $scope.$apply();
         });

--- a/client/ngapp/scripts/services/lbclient.js
+++ b/client/ngapp/scripts/services/lbclient.js
@@ -18,5 +18,4 @@ angular.module('loopbackExampleFullStackApp')
   .value('RemoteTodo', client.models.RemoteTodo)
   .value('sync', client.sync)
   .value('network', client.network)
-  .value('proquint', client.proquint)
-  .value('Buffer', client.Buffer);
+  .value('getReadableModelId', client.getReadableModelId);


### PR DESCRIPTION
- Hide implementation details (such as Buffer and proquint)
- Export getSimpleModelId function instead

Connect to #67 