### PR TITLE
Fix replicate() args to correctly send "since"

### DIFF
--- a/client/lbclient/boot/replication.js
+++ b/client/lbclient/boot/replication.js
@@ -30,13 +30,13 @@ module.exports = function(client) {
   var since = { push: -1, pull: -1 };
   function sync(cb) {
     LocalTodo.replicate(
-      RemoteTodo,
       since.push,
+      RemoteTodo,
       function pushed(err, conflicts, cps) {
         since.push = cps;
         RemoteTodo.replicate(
-          LocalTodo,
           since.pull,
+          LocalTodo,
           function pulled(err, conflicts, cps) {
             since.pull = cps;
             if (cb) cb();


### PR DESCRIPTION
The example was making an incorrect call of `replicate` method which caused the method to always run with `since=-1`.

/to @ritch or @superkhau please review