### PR TITLE
Fixed incorrect project layout description

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ The project is composed from multiple components.
  - `common/models/` contains definition of models that are shared by both the server
   and the client.
 
- - `rest/` contains the REST API server; it exposes the shared models via
-  REST API.
-
  - `client/lbclient/` provides an isomorphic loopback client with offline synchronization.
   The client needs some client-only models for data synchronization. These
   models are defined in `client/lbclient/models/`.
@@ -50,7 +47,8 @@ The project is composed from multiple components.
   angular`, with a few modifications to make it work better in the full-stack
   project.
 
- - `server/` is the main HTTP server that brings together all other components.
+ - `server/` is the main HTTP server that brings together all other components. Also сontains the REST API server; it exposes the shared models via
+  REST API.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ The project is composed from multiple components.
  - `rest/` contains the REST API server; it exposes the shared models via
   REST API.
 
- - `lbclient/` provides an isomorphic loopback client with offline synchronization.
+ - `client/lbclient/` provides an isomorphic loopback client with offline synchronization.
   The client needs some client-only models for data synchronization. These
-  models are defined in `lbclient/models/`.
+  models are defined in `client/lbclient/models/`.
 
- - `ngapp/` is a single-page AngularJS application scaffolded using `yo
+ - `client/ngapp/` is a single-page AngularJS application scaffolded using `yo
   angular`, with a few modifications to make it work better in the full-stack
   project.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ following features:
 
 The project is composed from multiple components.
 
- - `models/` contains definition of models that are shared by both the server
+ - `common/models/` contains definition of models that are shared by both the server
   and the client.
 
  - `rest/` contains the REST API server; it exposes the shared models via


### PR DESCRIPTION
"models/" directory was moved to "common/models/"

Prooflink: this commit (maded a year ago): https://github.com/strongloop/loopback-example-offline-sync/commit/51c3c95d4b45162557ae612905dac19b364f36bd

We shoud have single place to store a shared models. Readme.md says that we shoud folders "models/" AND "common/models" in root directory at the same time. Project code does not contains "models" folder in the root folder.

Official documentation also says that "models/" shoud be inside a "common/" folder: https://docs.strongloop.com/display/public/LB/Project+layout+reference

It all looks very confusing - so I think that is a documentation error, but I'm not very confident about it.
What project layout is correct for offline sync app?

Best regards,
Ilya.