### PR TITLE
server/test: fix expected DELETE response

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "async": "~0.9.0",
     "compression": "^1.0.9",
     "cors": "^2.7.1",
-    "loopback": "^2.22.0",
+    "loopback": "^2.25.0",
     "loopback-boot": "^2.12.1",
     "loopback-connector-mongodb": "^1.4.1",
     "loopback-datasource-juggler": "^2.0.0",

--- a/server/test/todo.test.js
+++ b/server/test/todo.test.js
@@ -92,8 +92,9 @@ describe('Todo', function() {
 
       // Delete the created todo
       lt.describe.whenCalledRemotely('DELETE', '/api/Todos/123', function() {
-        it('should respond with status 204 - todo:123 deleted', function() {
-          assert.equal(this.res.statusCode, 204);
+        it('should respond with status 200 - todo:123 deleted', function() {
+          assert.equal(this.res.statusCode, 200);
+          assert.equal(this.res.body.count, 1);
         });
 
         // Try to find it -- should return not found


### PR DESCRIPTION
As a result of recent changes in LoopBack, DELETE requests return
200 with `{ count: 1 }` as body now. Our test was expecting 204 and thus
failing.

This patch is fixing the issue.